### PR TITLE
Fix allow only users with "can edit posts" to reset cache

### DIFF
--- a/hestia-nginx-cache.php
+++ b/hestia-nginx-cache.php
@@ -10,6 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       Hestia Nginx Cache
  * Description:       Hestia Nginx Cache Integration for WordPress. Auto-purges the Nginx cache when needed.
+ * Plugin URI:				https://github.com/jakobbouchard/hestia-nginx-cache
  * Version:           2.1.0
  * Requires at least: 4.8
  * Requires PHP:      5.4
@@ -86,11 +87,14 @@ class Hestia_Nginx_Cache
 		load_plugin_textdomain(self::NAME, false, self::NAME . '/languages');
 
 		if (is_admin()) {
+			// Do not allow logged in users / subscribers to clear cache
+			if ( current_user_can( 'edit_posts' )){
 			require_once __DIR__ . '/includes/admin.php';
 			$this->admin = new Hestia_Nginx_Cache_Admin();
 
 			require_once __DIR__ . '/includes/site_health.php';
 			$this->site_health = new Hestia_Nginx_Cache_Site_Health();
+			}
 		}
 
 		foreach ($this->events as $event) {

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,9 @@ If your issues persist, do not hesitate to contact me via email!
 
 == Changelog ==
 
+= 2.1.1 =
+* Fixed require at least "Can edit posts" permission to reset cache
+
 = 2.1.0 =
 * Add a setting to disable the admin bar button.
 * Add a setting to change the admin bar button's text.


### PR DESCRIPTION
Manual clear cache button can be abused if subscribers  have access to the wp admin page to manage their profiles for example. To prevent users abusing the cache purge function an potentially causing extra load the button should be removed
