### PR TITLE
2.2.1: Make sure the nonce is always hidden

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: jakobbouchard
+ko_fi: jakobbouchard

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -4,3 +4,6 @@ li#wp-admin-bar-hestia-nginx-cache-manual-purge > .ab-item {
 li#wp-admin-bar-hestia-nginx-cache-manual-purge > .ab-item::before {
 	content: "\f515";
 }
+#hestia-nginx-cache-purge-wp-nonce {
+	display: none;
+}

--- a/hestia-nginx-cache.php
+++ b/hestia-nginx-cache.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Hestia Nginx Cache
  * Description:       Hestia Nginx Cache Integration for WordPress. Auto-purges the Nginx cache when needed.
  * Plugin URI:				https://github.com/jakobbouchard/hestia-nginx-cache
- * Version:           2.2.0
+ * Version:           2.2.1
  * Requires at least: 4.8
  * Requires PHP:      5.4
  * Author:            Jakob Bouchard
@@ -28,7 +28,7 @@ if (!defined('ABSPATH')) {
 class Hestia_Nginx_Cache
 {
 	public const NAME = 'hestia-nginx-cache';
-	public const VERSION = '2.2.0';
+	public const VERSION = '2.2.1';
 
 	private static $instance = null;
 	public static $plugin_basename = null;

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -229,7 +229,7 @@ class Hestia_Nginx_Cache_Admin
 
 	public function embed_wp_nonce()
 	{
-		echo '<span id="' . $this->plugin::NAME . '-purge-wp-nonce' . '" class="hidden">'
+		echo '<span id="' . $this->plugin::NAME . '-purge-wp-nonce' . '">'
 			. wp_create_nonce($this->plugin::NAME . '-purge-wp-nonce')
 			. '</span>';
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: cache, caching, wp-cache, flush, purge, hestia, hestiacp, nginx
 Requires at least: 4.8
 Tested up to: 6.1
 Requires PHP: 5.4
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPL v3
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -67,6 +67,9 @@ If you are using Cloudflare and get an error when purging the cache, enter the h
 If your issues persist, do not hesitate to contact me via email!
 
 == Changelog ==
+
+= 2.2.1 =
+* Make sure the nonce is always hidden.
 
 = 2.2.0 =
 * Show button on the frontend when logged in.


### PR DESCRIPTION
This PR just makes sure that the wp-nonce is always hidden. The `hidden` class is available in the admin, but not always in the frontend. The PR hides the nonce by adding `display: none` to its ID in CSS.