### PR TITLE
Update admin.php

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -210,9 +210,11 @@ class Hestia_Nginx_Cache_Admin
 		wp_enqueue_script($this->plugin::NAME);
 		if (!is_admin()) {
 			wp_localize_script(
-				$this->plugin::NAME,
-				'ajaxurl',
-				admin_url('admin-ajax.php')
+			    $this->plugin::NAME,
+			    'ajaxurl',
+			    array(
+			        'ajax_url' => admin_url('admin-ajax.php')
+			    )
 			);
 		}
 	}


### PR DESCRIPTION
To fix the following error as outputted by Query Monitor:  
`Function WP_Scripts::localize was called incorrectly. The $l10n parameter must be an array. To pass arbitrary data to scripts, use the wp_add_inline_script() function instead. (This message was added in version 5.7.0.)`