### PR TITLE
Bug: On frontend "Purge Nginx Cache" not working

### DIFF
--- a/hestia-nginx-cache.php
+++ b/hestia-nginx-cache.php
@@ -40,6 +40,7 @@ class Hestia_Nginx_Cache
 	private $purge = false;
 
 	private $events = array(
+		'publish_post',
 		'edit_post',
 		'save_post',
 		'post_updated',

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -212,9 +212,8 @@ class Hestia_Nginx_Cache_Admin
 			wp_localize_script(
 			    $this->plugin::NAME,
 			    'ajaxurl',
-			    array(
-			        'ajax_url' => admin_url('admin-ajax.php')
-			    )
+			    admin_url('admin-ajax.php')
+
 			);
 		}
 	}


### PR DESCRIPTION
On the front end ajaxurl  was an Object  ajaxurl.ajax_url 

This PR address this bug

https://wordpress.org/support/topic/the-hestia-nginx-cache-was-purged-successfully-not-show-in-page-site/

Also include "publish_post" as it may be triggered on time instead "manually"
