### PR TITLE
Add some frontend notice

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,6 +5,13 @@ window.addEventListener("DOMContentLoaded", (_evt) => {
 	async function showNotice(resOrError) {
 		const container = document.querySelector("#hestia-nginx-cache-admin-notices");
 		if (!container) {
+			if(!resOrError.ok){
+				console.error(resOrError);
+				alert('The Hestia Nginx Cache could not be purged!');
+			}else{
+				const { success, data } = await resOrError.clone().json();
+				alert(data.message);
+			}
 			return;
 		}
 		const oldNotice = container.querySelector(".notice");


### PR DESCRIPTION
When hestia-nginx-cache-admin-notices is missing no feedback is provided to the user.

This might cause issues with triggering it more times than usually..

For now at least an "Error" message should be shown
